### PR TITLE
fix: repair chromium installation failure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*                   @RadxaYuntian

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Package: rockchip-chromium-x11-utils
 Architecture: all
 Section: admin
 Priority: standard
+Breaks: rockchip-chromium-x11-utils (<< 0.2.0)
 Depends: ${misc:Depends},
 Enhances: chromium-x11
 Description: Support package for Rockchip Chromium

--- a/debian/rockchip-chromium-x11-utils.lintian-overrides
+++ b/debian/rockchip-chromium-x11-utils.lintian-overrides
@@ -3,3 +3,6 @@ rockchip-chromium-x11-utils: improbable-bug-number-in-closes
 
 # Ignore troff warning
 rockchip-chromium-x11-utils: groff-message
+
+# We does conflict with our older versions
+rockchip-chromium-x11-utils: package-relation-with-self

--- a/debian/rockchip-chromium-x11-utils.preinst
+++ b/debian/rockchip-chromium-x11-utils.preinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+case $1 in
+    upgrade)
+        # `chromium-wrapper` is no longer provided
+        # Clean up dpkg-divert for version << 0.2.0
+        conflicts="/usr/lib/chromium/chromium-wrapper"
+        if [ "$(dpkg-divert --listpackage "$conflicts")" = "rockchip-chromium-x11-utils" ]
+        then
+            dpkg-divert --package rockchip-chromium-x11-utils --rename --remove "$conflicts"
+        fi
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
remove dpkg-divert from older package before install