### PR TITLE
fix: use --no-rename option for dpkg-divert

### DIFF
--- a/debian/rockchip-chromium-x11-utils.postinst
+++ b/debian/rockchip-chromium-x11-utils.postinst
@@ -2,7 +2,7 @@
 set -e
 
 case $1 in
-    upgrade)
+    configure)
         # `chromium-wrapper` is no longer provided
         # Clean up dpkg-divert for version << 0.2.0
         conflicts="/usr/lib/chromium/chromium-wrapper"


### PR DESCRIPTION
To fix upgrade failed
```bash
Removing 'diversion of /usr/lib/chromium/chromium-wrapper to /usr/lib/chromium/chromium-wrapper.bak by rockchip-chromium-x11-utils'
dpkg-divert: error: rename involves overwriting '/usr/lib/chromium/chromium-wrapper' with
  different file '/usr/lib/chromium/chromium-wrapper.bak', not allowed
```